### PR TITLE
Install also sub-modules bufrpy.template, bufrpy.table and bufrpy.tool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path, 'rU') as file:
 
 
 setup(name="bufrpy",
-      packages=["bufrpy"],
+      packages=["bufrpy", "bufrpy.template", "bufrpy.table", "bufrpy.tool"],
       version=version,
       description="Pyre-Python BUFR decoder",
       url="https://github.com/tazle/bufrpy",


### PR DESCRIPTION
When running "python setup.py install --user" the sub-modules bufrpy.template, bufrpy.table and bufrpy.tool were not installed, so added those to list of packages.